### PR TITLE
Issue3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ eslint_report.htm
 ### VisualStudioCode Patch ###
 # Ignore all local history of files
 .history
+.idea/inspectionProfiles/Project_Default.xml
+.idea/modules.xml
+.idea/vcs.xml
+.idea/workspace.xml
+.idea/Zettlr.iml

--- a/source/main/zettlr.ts
+++ b/source/main/zettlr.ts
@@ -38,7 +38,7 @@ export default class Zettlr {
   _openPaths: any
   _fsal: FSAL
   _commands: any[]
-  tray: any
+  tray: Tray|null
   private readonly _windowManager: WindowManager
   private readonly isShownFor: string[]
 
@@ -847,19 +847,17 @@ export default class Zettlr {
 
   /**
    * Initialize the tray icon
-   *
-   * @return  {Tray}  tray class to manage the tray icon
    */
   initTray (): void {
-    let tempTray = new Tray('source/main/assets/icons/128x128.png') // Assign the icon image
+    this.tray = new Tray('source/main/assets/icons/128x128.png') // Assign the icon image
     // Define a context menu, triggered when right click the tray icon
     const contextMenu = Menu.buildFromTemplate([
       { label: 'Show Zettlr', type: 'normal' },
+      { type: 'separator' },
       { label: 'Quit', type: 'normal' }
     ])
-    tempTray.setToolTip('Zettlr editor') // A tooltip when move the cursor on the icon
-    tempTray.setContextMenu(contextMenu) // Set the context menu to tray icon
-    this.tray = tempTray
+    this.tray.setToolTip('Zettlr editor') // A tooltip when move the cursor on the icon
+    this.tray.setContextMenu(contextMenu) // Set the context menu to tray icon
     global.log.info('Successfully initialize the tray icon') //
   }
 }

--- a/source/main/zettlr.ts
+++ b/source/main/zettlr.ts
@@ -14,7 +14,7 @@
  * END HEADER
  */
 
-import { app, BrowserWindow, FileFilter, ipcMain, MessageBoxReturnValue } from 'electron'
+import { app, BrowserWindow, FileFilter, ipcMain, MessageBoxReturnValue, Menu, Tray } from 'electron'
 import path from 'path'
 import fs from 'fs'
 
@@ -38,6 +38,7 @@ export default class Zettlr {
   _openPaths: any
   _fsal: FSAL
   _commands: any[]
+  tray: any
   private readonly _windowManager: WindowManager
   private readonly isShownFor: string[]
 
@@ -50,6 +51,7 @@ export default class Zettlr {
     this.editFlag = false // Is the current opened file edited?
     this._openPaths = [] // Holds all currently opened paths.
     this.isShownFor = [] // Contains all files for which remote notifications are currently shown
+    this.tray = null // variable use to set the tray icon
 
     this._windowManager = new WindowManager()
     // Immediately load persisted session data from disk
@@ -315,7 +317,6 @@ export default class Zettlr {
     // algorithms will make sure the roots will appear one after another in the
     // main window.
     this.openWindow()
-
     let start = Date.now()
     // First: Initially load all paths
     for (let p of global.config.get('openPaths') as string[]) {
@@ -365,6 +366,9 @@ export default class Zettlr {
 
     // Finally, initiate a first check for updates
     global.updates.check()
+
+    //  Init the tray icon
+    this.tray = this.initTray()
   }
 
   /**
@@ -839,5 +843,19 @@ export default class Zettlr {
    */
   prompt (options: any): void {
     this._windowManager.prompt(options)
+  }
+
+  /**
+   * Initialize the tray icon
+   */
+  initTray (): Tray {
+    let tray = new Tray('source/main/assets/icons/128x128.png')
+    const contextMenu = Menu.buildFromTemplate([
+      { label: 'Item1', type: 'radio' },
+      { label: 'Item2', type: 'radio' }
+    ])
+    tray.setToolTip('This is my application.')
+    tray.setContextMenu(contextMenu)
+    return tray
   }
 }

--- a/source/main/zettlr.ts
+++ b/source/main/zettlr.ts
@@ -367,8 +367,8 @@ export default class Zettlr {
     // Finally, initiate a first check for updates
     global.updates.check()
 
-    //  Init the tray icon
-    this.tray = this.initTray()
+    // Initialize the tray icon
+    this.initTray()
   }
 
   /**
@@ -847,15 +847,19 @@ export default class Zettlr {
 
   /**
    * Initialize the tray icon
+   *
+   * @return  {Tray}  tray class to manage the tray icon
    */
-  initTray (): Tray {
-    let tray = new Tray('source/main/assets/icons/128x128.png')
+  initTray (): void {
+    let tempTray = new Tray('source/main/assets/icons/128x128.png') // Assign the icon image
+    // Define a context menu, triggered when right click the tray icon
     const contextMenu = Menu.buildFromTemplate([
-      { label: 'Item1', type: 'radio' },
-      { label: 'Item2', type: 'radio' }
+      { label: 'Show Zettlr', type: 'normal' },
+      { label: 'Quit', type: 'normal' }
     ])
-    tray.setToolTip('This is my application.')
-    tray.setContextMenu(contextMenu)
-    return tray
+    tempTray.setToolTip('Zettlr editor') // A tooltip when move the cursor on the icon
+    tempTray.setContextMenu(contextMenu) // Set the context menu to tray icon
+    this.tray = tempTray
+    global.log.info('Successfully initialize the tray icon') //
   }
 }


### PR DESCRIPTION
## Description

Enable the tray class to Zettlr which display an icon in system tray. By right clicking the icon, a menu shall display

## Changes

Add a new function to main/Zettlr.ts for initialize the tray icon. And call that function by the end of Zettlr.init().

## Additional information

- Currently, the tray icon is just an icon. It has no click event bound. 
- It is displayed before the display of main window. I can't find the function that initialize the main window. And it is displayed by the end of the initialize process of the application.
- Also, I have add the function in Zettlr, I am not sure such way is proper or not. Maybe we should create a new folder for the tray process.