### PR TITLE
Setup .icon file in assets for tray #175

### DIFF
--- a/forge.config.js
+++ b/forge.config.js
@@ -112,6 +112,11 @@ module.exports = {
         // If someone is building this on an unsupported platform, drop a warning.
         console.log(`\nBuilding for an unsupported platform/arch-combination ${targetPlatform}/${targetArch} - not bundling Pandoc.`)
       }
+
+      // setup tray icon
+      if (isWin32) {
+        await fs.copyFile(path.join(__dirname, './resources/icons/icon.ico'), path.join(__dirname, './source/main/modules/window-manager/assets/icons/icon.ico'))
+      }
     }
   },
   packagerConfig: {

--- a/source/main/modules/window-manager/assets/icons/.gitignore
+++ b/source/main/modules/window-manager/assets/icons/.gitignore
@@ -1,0 +1,3 @@
+# This icons folder is populated from resources/icons by forge.config.js
+*
+!.gitignore

--- a/webpack.main.config.js
+++ b/webpack.main.config.js
@@ -17,7 +17,8 @@ module.exports = {
         { from: 'source/app/service-providers/assets/defaults', to: 'assets/defaults' },
         { from: 'source/main/modules/export/assets/export.tpl.htm', to: 'assets' },
         { from: 'source/main/modules/export/assets/template.revealjs.htm', to: 'assets' },
-        { from: 'source/main/modules/export/assets/revealjs-styles', to: 'assets/revealjs-styles' }
+        { from: 'source/main/modules/export/assets/revealjs-styles', to: 'assets/revealjs-styles' },
+        { from: 'source/main/modules/window-manager/assets/icons', to: 'assets/icons' }
       ]
     })
   ],


### PR DESCRIPTION
Setup assets directory for the tray icon. The assets directory can be used for both development build and release packages.

Note: This pull request doesn't load the icon, but supports future code which can load the icon using:

```typescript
new Tray(path.join(__dirname, './assets/icons/icon.ico'))
```

The above will work during development and [install packages](https://github.com/UofA-SPI21-team7/zettlr-assignment/wiki/Zettlr-creating-packages). I tested install packages on Windows, Linux (Fedora) and MacOS.


Closes  UofA-SPI21-team7/Zettlr#16