### PR TITLE
Issue11

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -98,8 +98,10 @@ nsis:
 deb:
   priority: optional
   compression: xz
+  depends: ["libappindicator3-1"]
 #
 # Configuration for Fedora builds
 #
 rpm:
   compression: xz
+  depends: ["libappindicator-gtk3"]

--- a/forge.config.js
+++ b/forge.config.js
@@ -60,12 +60,12 @@ async function downloadPandoc (platform, arch) {
  * @returns {string}  The full path of the matching library. If library is not
  *                    found, throws an Error.
  */
-async function getLibraryPath(libraryName) {
+async function getLibraryPath (libraryName) {
   return new Promise((resolve, reject) => {
     const shellProcess = spawn('/sbin/ldconfig', ['-p'])
-    let out = '';
+    let out = ''
     shellProcess.stdout.on('data', (data) => {
-      out += data.toString();
+      out += data.toString()
     })
     shellProcess.on('close', (code, signal) => {
       if (code !== 0) {
@@ -75,12 +75,11 @@ async function getLibraryPath(libraryName) {
         if (index === -1) {
           reject(new Error(`'${code}' not found`))
         }
-        var left = out.slice(0, index + 1).search(/\S+$/)
-        var right = out.slice(index).search(/\s/)
+        let left = out.slice(0, index + 1).search(/\S+$/)
+        let right = out.slice(index).search(/\s/)
         if (right < 0) {
           resolve(out.slice(left))
         }
-        let retval = out.slice(left, right + index)
         resolve(out.slice(left, right + index))
       }
     })
@@ -168,19 +167,23 @@ module.exports = {
           targetArch = process.argv[idxArch + 1]
         }
         if (targetArch !== process.arch) {
-          if (options.spinner) {
-            options.spinner.info(`Unable to bundle 'libappindicator3' (target is different architecture).`)
-            return
+          if (options.spinner !== null && options.spinner !== undefined) {
+            options.spinner.info('Unable to bundle \'libappindicator3\' (target is different architecture).')
+          } else {
+            console.log('Unable to bundle \'libappindicator3\' (target is different architecture).')
           }
+          return
         }
 
         try {
           let lib = await getLibraryPath('libappindicator3')
-          await fs.mkdir(path.join(options.outputPaths[0], 'usr', 'lib'), { recursive: true})
+          await fs.mkdir(path.join(options.outputPaths[0], 'usr', 'lib'), { recursive: true })
           await fs.copyFile(lib, path.join(options.outputPaths[0], 'usr', 'lib', path.basename(lib)))
         } catch (err) {
-          if (options.spinner) {
+          if (options.spinner !== null && options.spinner !== undefined) {
             options.spinner.info(`Unable to bundle 'libappindicator3' (${err}).`)
+          } else {
+            console.log(`Unable to bundle 'libappindicator3' (${err}).`)
           }
         }
       }

--- a/forge.config.js
+++ b/forge.config.js
@@ -51,6 +51,47 @@ async function downloadPandoc (platform, arch) {
   })
 }
 
+/**
+ * This function returns the full path and filename to the library specified
+ * by `libraryName`. Uses ldconfig to determine the library location because
+ * libraries location varies.
+ *
+ * @param   {string}  libraryName  The name of the library.
+ * @returns {string}  The full path of the matching library. If library is not
+ *                    found, throws an Error.
+ */
+async function getLibraryPath(libraryName) {
+  return new Promise((resolve, reject) => {
+    const shellProcess = spawn('/sbin/ldconfig', ['-p'])
+    let out = '';
+    shellProcess.stdout.on('data', (data) => {
+      out += data.toString();
+    })
+    shellProcess.on('close', (code, signal) => {
+      if (code !== 0) {
+        reject(new Error(`Failed to run ldconfig: Process quit with code ${code}`))
+      } else {
+        let index = out.lastIndexOf(libraryName)
+        if (index === -1) {
+          reject(new Error(`'${code}' not found`))
+        }
+        var left = out.slice(0, index + 1).search(/\S+$/)
+        var right = out.slice(index).search(/\s/)
+        if (right < 0) {
+          resolve(out.slice(left))
+        }
+        let retval = out.slice(left, right + index)
+        resolve(out.slice(left, right + index))
+      }
+    })
+
+    // Reject on errors.
+    shellProcess.on('error', (err) => {
+      reject(err)
+    })
+  })
+}
+
 module.exports = {
   hooks: {
     generateAssets: async (forgeConfig) => {
@@ -111,6 +152,33 @@ module.exports = {
       } else {
         // If someone is building this on an unsupported platform, drop a warning.
         console.log(`\nBuilding for an unsupported platform/arch-combination ${targetPlatform}/${targetArch} - not bundling Pandoc.`)
+      }
+    },
+    postPackage: async (forgeConfig, options) => {
+      const isLinux = process.platform === 'linux'
+      if (isLinux) {
+        // bundle libappindicator3 in AppImage and zip packages. Needed for tray icon on Gnome
+        const idxArch = process.argv.indexOf('--arch')
+        let targetArch = process.arch
+        if (idxArch > -1 && process.argv.length > idxArch + 1) {
+          targetArch = process.argv[idxArch + 1]
+        }
+        if (targetArch !== process.arch) {
+          if (options.spinner) {
+            options.spinner.info(`Unable to bundle 'libappindicator3' (target is different architecture).`)
+            return
+          }
+        }
+
+        try {
+          let lib = await getLibraryPath('libappindicator3')
+          await fs.mkdir(path.join(options.outputPaths[0], 'usr', 'lib'), { recursive: true})
+          await fs.copyFile(lib, path.join(options.outputPaths[0], 'usr', 'lib', path.basename(lib)))
+        } catch (err) {
+          if (options.spinner) {
+            options.spinner.info(`Unable to bundle 'libappindicator3' (${err}).`)
+          }
+        }
       }
     }
   },


### PR DESCRIPTION
Add dependency on libappindicator for .rpm and .deb packages.
Bundle libappindicator  for .AppImage and .zip packages.

Add dependency on libappindicator for debian packages and rpm packages. libappindicator is only required for Gnome desktop. Avoid the added complexity of separate Zettlr packages for Gnome and non-Gnome, instead add the required dependency everywhere. The dependencies of libappindicator are not too arduous.

Bundle the system's libappindicator in AppImage & Zip packages. libappindicator is only required for Gnome desktop. deb and rpm packages do not use the bundled libappindicator but instead use the 'depends' mechanism. If libappindicator is not present, the packaging continues and an info message displayed. If packaging for a target architecture different than the host architecture, libappindicator is not bundled, the packaging continues and an info message displayed.

Closes #11 