### PR TITLE
Add check if system supports a tray.

### DIFF
--- a/source/common/lang/en-GB.json
+++ b/source/common/lang/en-GB.json
@@ -607,7 +607,8 @@
             "pandoc_error_message": "Pandoc reported an error: %s",
             "pandoc_error_title": "Could not export file",
             "remove_message": "Do you really want to remove %s?",
-            "remove_title": "Really delete?"
+            "remove_title": "Really delete?",
+            "tray_not_supported": "Tray is not supported. Gnome Extension 'KStatusNotifierItem/AppIndicator Support' is required for tray support on the Gnome Desktop."
         },
         "export_success": "Exporting to %s",
         "file_changed": "File %s has changed remotely.",

--- a/source/common/lang/en-US.json
+++ b/source/common/lang/en-US.json
@@ -607,7 +607,8 @@
             "pandoc_error_message": "Pandoc reported an error: %s",
             "pandoc_error_title": "Could not export file",
             "remove_message": "Do you really want to remove %s?",
-            "remove_title": "Really delete?"
+            "remove_title": "Really delete?",
+            "tray_not_supported": "Tray is not supported. Gnome Extension 'KStatusNotifierItem/AppIndicator Support' is required for Tray support on the Gnome Desktop."
         },
         "export_success": "Exporting to %s",
         "file_changed": "File %s has changed remotely.",


### PR DESCRIPTION
Add check if system supports a tray. Returns true on Windows and MacOS.
Returns true on Linux with Gnome desktop if Gnome Extension
'KStatusNotifierItem/AppIndicator Support' is installed, otherwise
false. Returns true on Linux with other desktops. e.g. KDE, XFCE, etc.

`isTraySupported` is not called yet. That is issue #13.

Passes `yarn lint`

Before testing the error string (error string has translation support), remove the translation cache (at `~/.config/Zettlr/lang` on Linux). Otherwise the language cache is used instead.

Closes #12 