### PR TITLE
Add 'Leave app running in the notification area' preference

### DIFF
--- a/source/app/service-providers/assets/get-config-template.ts
+++ b/source/app/service-providers/assets/get-config-template.ts
@@ -211,6 +211,7 @@ export default function getConfigTemplate (): ConfigOptions {
     },
     system: {
       deleteOnFail: false, // Whether to delete files if trashing them fails
+      leaveAppRunning: false, // Whether to leave app running in the notification area (tray)
       avoidNewTabs: true // Whether to avoid opening new tabs for documents if possible
     },
     checkForBeta: false, // Should the user be notified of beta releases?

--- a/source/app/service-providers/assets/types.config-provider.d.ts
+++ b/source/app/service-providers/assets/types.config-provider.d.ts
@@ -143,6 +143,7 @@ interface ConfigOptions {
   }
   system: {
     deleteOnFail: boolean
+    leaveAppRunning: boolean
     avoidNewTabs: boolean
   }
   checkForBeta: boolean

--- a/source/win-preferences/schema/advanced.js
+++ b/source/win-preferences/schema/advanced.js
@@ -35,6 +35,11 @@ export default {
         type: 'checkbox',
         label: trans('dialog.preferences.delete_on_fail'),
         model: 'system.deleteOnFail'
+      },
+      {
+        type: 'checkbox',
+        label: 'Leave app running in the notification area', // trans('dialog.preferences.leave_app_running'),
+        model: 'system.leaveAppRunning'
       }
     ],
     [


### PR DESCRIPTION
In Advanced preferences, add the option 'Leave app running in the
notification area'. Defaults to false. Preference persists.

![Screenshot 2021-04-27 220558](https://user-images.githubusercontent.com/5193990/116243086-ba2ebe00-a7a5-11eb-90fa-7bd7f5815ac0.png)

Note: This code has an untranslated string:
``` typescript
'Leave app running in the notification area', // trans('dialog.preferences.leave_app_running'),
```

The developer hendrik said in this [forum post](https://forum.zettlr.com/discussion/417/how-to-add-translatable-strings-to-zettlr-during-development) to add strings in this way.

Closes #1 