### PR TITLE
Disable pref if AppIndicator Support not detected

### DIFF
--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -132,7 +132,14 @@ export default async function environmentCheck (): Promise<void> {
     }
   }
 
-  process.env.ZETTLR_IS_TRAY_SUPPORTED = (await isTraySupported()).value.toString()
+  try {
+    if (await isTraySupported()) {
+      process.env.ZETTLR_IS_TRAY_SUPPORTED = '1'
+    }
+  } catch (err) {
+    process.env.ZETTLR_IS_TRAY_SUPPORTED = '0'
+    global.log.warning(err)
+  }
 
   global.log.info('Environment check complete.')
 }

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -133,12 +133,10 @@ export default async function environmentCheck (): Promise<void> {
   }
 
   try {
-    if (await isTraySupported()) {
-      process.env.ZETTLR_IS_TRAY_SUPPORTED = '1'
-    }
+    process.env.ZETTLR_IS_TRAY_SUPPORTED = await isTraySupported() ? '1' : '0'
   } catch (err) {
     process.env.ZETTLR_IS_TRAY_SUPPORTED = '0'
-    global.log.warning(err)
+    global.log.warning(err.message)
   }
 
   global.log.info('Environment check complete.')

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -132,6 +132,8 @@ export default async function environmentCheck (): Promise<void> {
     }
   }
 
+  process.env.ZETTLR_IS_TRAY_SUPPORTED = (await isTraySupported()).value.toString()
+
   global.log.info('Environment check complete.')
 }
 

--- a/source/common/vue/form/Form.vue
+++ b/source/common/vue/form/Form.vue
@@ -58,6 +58,7 @@
           v-bind:value="getModelValue(field.model)"
           v-bind:label="field.label"
           v-bind:name="field.model"
+          v-bind:disabled="field.disabled"
           v-on:input="$emit('input', field.model, $event)"
         ></CheckboxInput>
         <SwitchInput

--- a/source/common/vue/form/elements/Checkbox.vue
+++ b/source/common/vue/form/elements/Checkbox.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="form-control cb-group">
-    <label class="checkbox">
+    <label class="checkbox"
+           v-bind:disabled="disabled"
+    >
       <input
         v-bind:id="fieldID"
         type="checkbox" v-bind:name="name" value="yes"
@@ -10,7 +12,9 @@
       >
       <span class="checkmark"></span>
     </label>
-    <label v-if="label" v-bind:for="fieldID" v-html="label"></label>
+    <label v-if="label" v-bind:for="fieldID" v-bind:disabled="disabled"
+           v-html="label">
+    </label>
   </div>
 </template>
 
@@ -95,6 +99,21 @@ body {
       &:after {
         opacity: 1;
       }
+    }
+
+    &[disabled] {
+      input:checked ~ .checkmark {
+        background-color: lightgrey;
+      }
+      input:checked ~ .checkmark {
+        border-color: rgb(90, 90, 90);
+      }
+    }
+  }
+
+  label{
+    &[disabled] {
+      color: grey;
     }
   }
 }

--- a/source/win-preferences/preferences.vue
+++ b/source/win-preferences/preferences.vue
@@ -237,7 +237,7 @@ export default {
       }
     })
 
-    if (process.env.ZETTLR_IS_TRAY_SUPPORTED === 'false') {
+    if (process.env.ZETTLR_IS_TRAY_SUPPORTED === '0') {
       const leaveAppRunningField = modelToField('system.leaveAppRunning', SCHEMA['tab-advanced'])
       if (leaveAppRunningField !== undefined) {
         global.config.set('system.leaveAppRunning', false)

--- a/source/win-preferences/preferences.vue
+++ b/source/win-preferences/preferences.vue
@@ -236,6 +236,14 @@ export default {
         this.populateDynamicValues()
       }
     })
+
+    if (process.env.ZETTLR_IS_TRAY_SUPPORTED === 'false') {
+      const leaveAppRunningField = modelToField('system.leaveAppRunning', SCHEMA['tab-advanced'])
+      if (leaveAppRunningField !== undefined) {
+        global.config.set('system.leaveAppRunning', false)
+        leaveAppRunningField.disabled = true
+      }
+    }
   },
   methods: {
     /**


### PR DESCRIPTION
If running Linux and Gnome Desktop and AppIndicator Support [1] support is not detected, disable the preference `Leave app running in the notification area` and set to false. Style the disabled preference (Linux only). Style is suitable for normal mode and dark mode. Uses an environment variable as suggested by @nathanlesage [2]

[1] https://extensions.gnome.org/extension/615/appindicator-support/
[2] https://github.com/Zettlr/Zettlr/issues/175#issuecomment-814900960

Passes  `yarn lint`.

Closes #13 