### PR TITLE
 In isTraySupported() use exception rather than custom type linux

### DIFF
--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -134,29 +134,26 @@ export default async function environmentCheck (): Promise<void> {
   global.log.info('Environment check complete.')
 }
 
-export interface BooleanError {
-  value: boolean
-  err?: string
-}
-
 /**
  * Check if system supports a Tray.
  *
- * Returns {value: true} on Windows and MacOS.
- * Returns {value: true} on Linux with Gnome desktop if Gnome Extension
- * 'KStatusNotifierItem/AppIndicator Support' is installed, otherwise false.
- * Returns {value: true} on Linux with other desktops. e.g. KDE, XFCE, etc.
+ * Returns true on Windows and MacOS.
+ * Returns true on Linux with Gnome desktop if Gnome Extension
+ * 'KStatusNotifierItem/AppIndicator Support' is installed, otherwise throws
+ * an {Error} with the reason why.
+ * Returns true on Linux with other desktops. e.g. KDE, XFCE, etc.
  *
- * @return {*}  {Promise<BooleanError>} If supported, returns {value: true}.
- *              If not supported, returns {value: false, err: error_string}.
- *              error_string details why the Tray is not supported. Throws an
- *              exception if an error occurred while checking Tray support.
+ * @return {*}  {Promise<Boolean>} If supported, returns true. Never returns
+ *              false.
+ * @throws {Error} Details why the Tray is not supported; or
+ *                 Details the error if an error occurred while checking Tray
+ *                 support.
  */
-export async function isTraySupported (): Promise<BooleanError> {
+export async function isTraySupported (): Promise<Boolean> {
   const isLinux = process.platform === 'linux'
   if (isLinux) {
     if (process.env.XDG_CURRENT_DESKTOP === 'GNOME') {
-      return await new Promise<BooleanError>((resolve, reject) => {
+      return await new Promise<Boolean>((resolve, reject) => {
         const shellProcess = spawn('gsettings', [ 'get', 'org.gnome.shell', 'enabled-extensions' ])
         let out = ''
 
@@ -166,21 +163,17 @@ export async function isTraySupported (): Promise<BooleanError> {
 
         shellProcess.on('close', (code, signal) => {
           if (code !== 0) {
-            resolve({
-              value: false,
-              err: 'Tray is not supported. Gnome ' +
-                'Extension \'KStatusNotifierItem/AppIndicator Support\' is ' +
-                'required for Tray support on the Gnome Desktop.'
-            }) // trans('system.error.tray_not_supported')
+            reject(new Error('Tray is not supported. Gnome ' +
+              'Extension \'KStatusNotifierItem/AppIndicator Support\' is ' +
+              'required for Tray support on the Gnome Desktop.'
+            )) // trans('system.error.tray_not_supported')
           } else if (out.includes("'appindicatorsupport@rgcjonas.gmail.com'")) {
-            resolve({ value: true })
+            resolve(true)
           } else {
-            resolve({
-              value: false,
-              err: 'Tray is not supported. Gnome ' +
-                'Extension \'KStatusNotifierItem/AppIndicator Support\' is ' +
-                'required for Tray support on the Gnome Desktop.'
-            }) // trans('system.error.tray_not_supported')
+            reject(new Error('Tray is not supported. Gnome ' +
+              'Extension \'KStatusNotifierItem/AppIndicator Support\' is ' +
+              'required for Tray support on the Gnome Desktop.'
+            )) // trans('system.error.tray_not_supported')
           }
         })
 
@@ -191,5 +184,5 @@ export async function isTraySupported (): Promise<BooleanError> {
       })
     }
   }
-  return ({ value: true })
+  return (true)
 }

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -143,17 +143,17 @@ export default async function environmentCheck (): Promise<void> {
  * an {Error} with the reason why.
  * Returns true on Linux with other desktops. e.g. KDE, XFCE, etc.
  *
- * @return {*}  {Promise<Boolean>} If supported, returns true. Never returns
+ * @return {*}  {Promise<boolean>} If supported, returns true. Never returns
  *              false.
  * @throws {Error} Details why the Tray is not supported; or
  *                 Details the error if an error occurred while checking Tray
  *                 support.
  */
-export async function isTraySupported (): Promise<Boolean> {
+export async function isTraySupported (): Promise<boolean> {
   const isLinux = process.platform === 'linux'
   if (isLinux) {
     if (process.env.XDG_CURRENT_DESKTOP === 'GNOME') {
-      return await new Promise<Boolean>((resolve, reject) => {
+      return await new Promise<boolean>((resolve, reject) => {
         const shellProcess = spawn('gsettings', [ 'get', 'org.gnome.shell', 'enabled-extensions' ])
         let out = ''
 

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -17,7 +17,6 @@ import { app } from 'electron'
 import { promises as fs } from 'fs'
 import { spawn } from 'child_process'
 import isFile from '../../common/util/is-file'
-import { trans } from '../../common/i18n'
 
 /**
  * Contains custom paths that should be present on the process.env.PATH property
@@ -167,11 +166,21 @@ export async function isTraySupported (): Promise<BooleanError> {
 
         shellProcess.on('close', (code, signal) => {
           if (code !== 0) {
-            resolve({ value: false, err: trans('system.error.tray_not_supported') })
+            resolve({
+              value: false,
+              err: 'Tray is not supported. Gnome ' +
+                'Extension \'KStatusNotifierItem/AppIndicator Support\' is ' +
+                'required for Tray support on the Gnome Desktop.'
+            }) // trans('system.error.tray_not_supported')
           } else if (out.includes("'appindicatorsupport@rgcjonas.gmail.com'")) {
             resolve({ value: true })
           } else {
-            resolve({ value: false, err: trans('system.error.tray_not_supported') })
+            resolve({
+              value: false,
+              err: 'Tray is not supported. Gnome ' +
+                'Extension \'KStatusNotifierItem/AppIndicator Support\' is ' +
+                'required for Tray support on the Gnome Desktop.'
+            }) // trans('system.error.tray_not_supported')
           }
         })
 

--- a/source/common/lang/en-GB.json
+++ b/source/common/lang/en-GB.json
@@ -607,8 +607,7 @@
             "pandoc_error_message": "Pandoc reported an error: %s",
             "pandoc_error_title": "Could not export file",
             "remove_message": "Do you really want to remove %s?",
-            "remove_title": "Really delete?",
-            "tray_not_supported": "Tray is not supported. Gnome Extension 'KStatusNotifierItem/AppIndicator Support' is required for tray support on the Gnome Desktop."
+            "remove_title": "Really delete?"
         },
         "export_success": "Exporting to %s",
         "file_changed": "File %s has changed remotely.",

--- a/source/common/lang/en-US.json
+++ b/source/common/lang/en-US.json
@@ -607,8 +607,7 @@
             "pandoc_error_message": "Pandoc reported an error: %s",
             "pandoc_error_title": "Could not export file",
             "remove_message": "Do you really want to remove %s?",
-            "remove_title": "Really delete?",
-            "tray_not_supported": "Tray is not supported. Gnome Extension 'KStatusNotifierItem/AppIndicator Support' is required for Tray support on the Gnome Desktop."
+            "remove_title": "Really delete?"
         },
         "export_success": "Exporting to %s",
         "file_changed": "File %s has changed remotely.",


### PR DESCRIPTION
Return {Boolean} and throw {Error} rather than custom type in
`isTraySupported ()`

This pull request depends on #32. The  review (below) will include the one commit from #32.
(This branch 'issue34' was created from branch 'issue31' because it builds upon 'issue31' work)

Closes #34