### PR TITLE
Show help why tray preference is disabled 

### DIFF
--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -132,7 +132,14 @@ export default async function environmentCheck (): Promise<void> {
     }
   }
 
-  process.env.ZETTLR_IS_TRAY_SUPPORTED = (await isTraySupported()).value.toString()
+  try {
+    if (await isTraySupported()) {
+      process.env.ZETTLR_IS_TRAY_SUPPORTED = '1'
+    }
+  } catch (err) {
+    process.env.ZETTLR_IS_TRAY_SUPPORTED = '0'
+    global.log.warning(err)
+  }
 
   global.log.info('Environment check complete.')
 }

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -133,12 +133,10 @@ export default async function environmentCheck (): Promise<void> {
   }
 
   try {
-    if (await isTraySupported()) {
-      process.env.ZETTLR_IS_TRAY_SUPPORTED = '1'
-    }
+    process.env.ZETTLR_IS_TRAY_SUPPORTED = await isTraySupported() ? '1' : '0'
   } catch (err) {
     process.env.ZETTLR_IS_TRAY_SUPPORTED = '0'
-    global.log.warning(err)
+    global.log.warning(err.message)
   }
 
   global.log.info('Environment check complete.')

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -132,6 +132,8 @@ export default async function environmentCheck (): Promise<void> {
     }
   }
 
+  process.env.ZETTLR_IS_TRAY_SUPPORTED = (await isTraySupported()).value.toString()
+
   global.log.info('Environment check complete.')
 }
 

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -136,6 +136,7 @@ export default async function environmentCheck (): Promise<void> {
     process.env.ZETTLR_IS_TRAY_SUPPORTED = await isTraySupported() ? '1' : '0'
   } catch (err) {
     process.env.ZETTLR_IS_TRAY_SUPPORTED = '0'
+    process.env.ZETTLR_TRAY_ERROR = err.message
     global.log.warning(err.message)
   }
 

--- a/source/common/vue/form/Form.vue
+++ b/source/common/vue/form/Form.vue
@@ -58,6 +58,7 @@
           v-bind:value="getModelValue(field.model)"
           v-bind:label="field.label"
           v-bind:name="field.model"
+          v-bind:disabled="field.disabled"
           v-on:input="$emit('input', field.model, $event)"
         ></CheckboxInput>
         <SwitchInput

--- a/source/common/vue/form/Form.vue
+++ b/source/common/vue/form/Form.vue
@@ -59,6 +59,7 @@
           v-bind:label="field.label"
           v-bind:name="field.model"
           v-bind:disabled="field.disabled"
+          v-bind:additionaltext="field.additionaltext"
           v-on:input="$emit('input', field.model, $event)"
         ></CheckboxInput>
         <SwitchInput

--- a/source/common/vue/form/elements/Checkbox.vue
+++ b/source/common/vue/form/elements/Checkbox.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="form-control cb-group">
-    <label class="checkbox">
+    <label class="checkbox"
+           v-bind:disabled="disabled"
+    >
       <input
         v-bind:id="fieldID"
         type="checkbox" v-bind:name="name" value="yes"
@@ -10,7 +12,9 @@
       >
       <span class="checkmark"></span>
     </label>
-    <label v-if="label" v-bind:for="fieldID" v-html="label"></label>
+    <label v-if="label" v-bind:for="fieldID" v-bind:disabled="disabled"
+           v-html="label">
+    </label>
   </div>
 </template>
 
@@ -95,6 +99,21 @@ body {
       &:after {
         opacity: 1;
       }
+    }
+
+    &[disabled] {
+      input:checked ~ .checkmark {
+        background-color: lightgrey;
+      }
+      input:checked ~ .checkmark {
+        border-color: rgb(90, 90, 90);
+      }
+    }
+  }
+
+  label{
+    &[disabled] {
+      color: grey;
     }
   }
 }

--- a/source/common/vue/form/elements/Checkbox.vue
+++ b/source/common/vue/form/elements/Checkbox.vue
@@ -1,20 +1,26 @@
 <template>
-  <div class="form-control cb-group">
-    <label class="checkbox"
-           v-bind:disabled="disabled"
-    >
-      <input
-        v-bind:id="fieldID"
-        type="checkbox" v-bind:name="name" value="yes"
-        v-bind:checked="value"
-        v-bind:disabled="disabled"
-        v-on:input="$emit('input', $event.target.checked)"
+  <div>
+    <div class="form-control cb-group">
+      <label class="checkbox"
+             v-bind:disabled="disabled"
       >
-      <span class="checkmark"></span>
-    </label>
-    <label v-if="label" v-bind:for="fieldID" v-bind:disabled="disabled"
-           v-html="label">
-    </label>
+        <input
+          v-bind:id="fieldID"
+          type="checkbox" v-bind:name="name" value="yes"
+          v-bind:checked="value"
+          v-bind:disabled="disabled"
+          v-on:input="$emit('input', $event.target.checked)"
+        >
+        <span class="checkmark"></span>
+      </label>
+      <label v-if="label" v-bind:for="fieldID" v-bind:disabled="disabled"
+             v-html="label"
+      >
+      </label>
+    </div>
+    <div v-if="additionaltext" class="form-control">
+      {{ additionaltext }}
+    </div>
   </div>
 </template>
 
@@ -37,6 +43,10 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    },
+    additionaltext: {
+      type: String,
+      default: ''
     }
   },
   computed: {

--- a/source/win-preferences/preferences.vue
+++ b/source/win-preferences/preferences.vue
@@ -242,6 +242,9 @@ export default {
       if (leaveAppRunningField !== undefined) {
         global.config.set('system.leaveAppRunning', false)
         leaveAppRunningField.disabled = true
+        if (process.env.ZETTLR_TRAY_ERROR !== undefined) {
+          leaveAppRunningField.additionaltext = '⚠️ ' + process.env.ZETTLR_TRAY_ERROR
+        }
       }
     }
   },

--- a/source/win-preferences/preferences.vue
+++ b/source/win-preferences/preferences.vue
@@ -237,7 +237,7 @@ export default {
       }
     })
 
-    if (process.env.ZETTLR_IS_TRAY_SUPPORTED === 'false') {
+    if (process.env.ZETTLR_IS_TRAY_SUPPORTED === '0') {
       const leaveAppRunningField = modelToField('system.leaveAppRunning', SCHEMA['tab-advanced'])
       if (leaveAppRunningField !== undefined) {
         global.config.set('system.leaveAppRunning', false)

--- a/source/win-preferences/preferences.vue
+++ b/source/win-preferences/preferences.vue
@@ -236,6 +236,14 @@ export default {
         this.populateDynamicValues()
       }
     })
+
+    if (process.env.ZETTLR_IS_TRAY_SUPPORTED === 'false') {
+      const leaveAppRunningField = modelToField('system.leaveAppRunning', SCHEMA['tab-advanced'])
+      if (leaveAppRunningField !== undefined) {
+        global.config.set('system.leaveAppRunning', false)
+        leaveAppRunningField.disabled = true
+      }
+    }
   },
   methods: {
     /**


### PR DESCRIPTION
If running Gnome Desktop and if Gnome Extension AppIndicator Support is
not detected, show hover-over help why preference is disabled.

![Screenshot from 2021-05-04 22-54-09](https://user-images.githubusercontent.com/5193990/117012082-b4992100-ad2d-11eb-8ee2-f03eb8923839.png)

This pull request depends on: #35 which depends on #32. Therefore below will also contain commits from #35 and #32. Ideally, review #32, then review #35, then review this pull request.

Closes #14 