### PR TITLE
Quit, except if MacOS or `system.leaveAppRunning`

### DIFF
--- a/source/main.ts
+++ b/source/main.ts
@@ -157,12 +157,14 @@ app.on('open-file', (e, p) => {
 })
 
 /**
- * Quit as soon as all windows are closed and we are not on macOS.
+ * Quit as soon as all windows are closed. Except if
+ * `system.leaveAppRunning` is true or on macOS.
  */
 app.on('window-all-closed', function () {
-  // On OS X it is common for applications and their menu bar
-  // to stay active until the user quits explicitly with Cmd + Q
-  if (process.platform !== 'darwin') {
+  const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
+  if (!leaveAppRunning && process.platform !== 'darwin') {
+    // On OS X it is common for applications and their menu bar
+    // to stay active until the user quits explicitly with Cmd + Q
     app.quit()
   }
 })

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -353,15 +353,14 @@ export default class WindowManager {
           win.close()
         }
       }
-      let leaveAppRunning = false
       if (process.platform === 'win32' || process.platform === 'linux') {
-        leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
+        const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
         if (leaveAppRunning) {
           this._mainWindow?.hide()
         }
       }
 
-      if (this._beforeMainWindowCloseCallback !== null && !leaveAppRunning) {
+      if (this._beforeMainWindowCloseCallback !== null) {
         const shouldClose: boolean = this._beforeMainWindowCloseCallback()
         if (!shouldClose) {
           event.preventDefault()

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -353,16 +353,15 @@ export default class WindowManager {
           win.close()
         }
       }
+      let leaveAppRunning = false
       if (process.platform === 'win32' || process.platform === 'linux') {
-        const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
+        leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
         if (leaveAppRunning) {
-          event.preventDefault()
           this._mainWindow?.hide()
-          return
         }
       }
 
-      if (this._beforeMainWindowCloseCallback !== null) {
+      if (this._beforeMainWindowCloseCallback !== null && !leaveAppRunning) {
         const shouldClose: boolean = this._beforeMainWindowCloseCallback()
         if (!shouldClose) {
           event.preventDefault()


### PR DESCRIPTION
Quit as soon as all windows are closed. Except if `system.leaveAppRunning` is true or on macOS.

Closes #57 