### PR TITLE
Add `TrayProvider` to provide system tray services

### DIFF
--- a/source/app/lifecycle.ts
+++ b/source/app/lifecycle.ts
@@ -43,6 +43,7 @@ import TranslationProvider from './service-providers/translation-provider'
 import UpdateProvider from './service-providers/update-provider'
 import NotificationProvider from './service-providers/notification-provider'
 import StatsProvider from './service-providers/stats-provider'
+import TrayProvider from './service-providers/tray-provider'
 
 // We need module-global variables so that garbage collect won't shut down the
 // providers before the app is shut down.
@@ -61,6 +62,7 @@ let updateProvider: UpdateProvider
 let menuProvider: MenuProvider
 let notificationProvider: NotificationProvider
 let statsProvider: StatsProvider
+let trayProvider: TrayProvider
 
 // Statistics: Record the uptime of the application
 let upTimestamp: number
@@ -124,6 +126,7 @@ export async function bootApplication (): Promise<void> {
   updateProvider = new UpdateProvider()
   notificationProvider = new NotificationProvider()
   statsProvider = new StatsProvider()
+  trayProvider = new TrayProvider()
 
   // If the user has provided a working path to XeLaTeX, make sure that its
   // directory name is in path for Zettlr to find it.
@@ -192,6 +195,7 @@ export async function shutdownApplication (): Promise<void> {
   await safeShutdown(configProvider)
   await safeShutdown(statsProvider)
   await safeShutdown(assetsProvider)
+  await safeShutdown(trayProvider)
 
   const downTimestamp = Date.now()
 

--- a/source/app/service-providers/assets/types.tray-provider.d.ts
+++ b/source/app/service-providers/assets/types.tray-provider.d.ts
@@ -1,0 +1,4 @@
+interface TrayProvider {
+  add: (show: () => void, quit: () => void) => void
+  remove: () => void
+}

--- a/source/app/service-providers/tray-provider.ts
+++ b/source/app/service-providers/tray-provider.ts
@@ -1,0 +1,143 @@
+/**
+ * @ignore
+ * BEGIN HEADER
+ *
+ * Contains:        TrayProvider
+ * CVM-Role:        Service Provider
+ * Maintainer:      Hendrik Erz
+ * License:         GNU GPL v3
+ *
+ * Description:     Tray provider of electron's Tray class.
+ *
+ * END HEADER
+ */
+
+import {
+  Tray,
+  Menu,
+  screen
+} from 'electron'
+import path from 'path'
+import EventEmitter from 'events'
+
+/**
+ * This class generates the Tray in the system notification area
+ */
+export default class TrayProvider extends EventEmitter {
+  /**
+   * The tray
+   */
+  private _tray: Tray | null
+
+  /**
+   * Create the instance on program start and setup services.
+   */
+  constructor () {
+    super()
+    global.log.verbose('Tray provider booting up ...')
+    this._tray = null
+
+    global.tray = {
+      /**
+       * Add a document to the list of recently opened documents
+       * @param {Object} doc A document exposing at least the metadata of the file
+       */
+      add: (show: () => void, quit: () => void) => {
+        this._addTray(show, quit)
+      },
+
+      remove: () => {
+        this._removeTray()
+      }
+    }
+  }
+
+  /**
+   * Shuts down the provider
+   *
+   * @return  {boolean} Always returns true
+   */
+  shutdown (): boolean {
+    global.log.verbose('Tray provider shutting down ...')
+    return true // This provider needs no special shutdown logic
+  }
+
+  /**
+   * Return a suitable tray icon size
+   * @private
+   * @memberof TrayProvider
+   */
+  private _calcTrayIconSize (): number {
+    let size = 32
+    const fitSize = (size: number): number => {
+      const sizeList = [ 32, 48, 64, 96, 128, 256 ]
+      for (let s of sizeList) {
+        if (s >= size) {
+          return s
+        }
+      }
+      return 32
+    }
+    const display = screen.getPrimaryDisplay()
+    size = display.workArea.y
+    if (size >= 8 && size <= 256) {
+      size = fitSize(size)
+    } else {
+      size = display.size.height - display.workArea.height
+      size = fitSize(size)
+    }
+    return size
+  }
+
+  /**
+   * Adds the Zettlr tray to the system notification area.
+   * @private
+   * @memberof TrayProvider
+   */
+  private _addTray (show: () => void, quit: () => void): void {
+    if (this._tray == null) {
+      const platformIcons: { [key in 'darwin' | 'win32']: string } = {
+        'darwin': '/png/22x22_white.png',
+        'win32': '/icon.ico'
+      }
+      if (process.platform === 'linux') {
+        const size = this._calcTrayIconSize()
+        this._tray = new Tray(path.join(__dirname, `assets/icons/png/${size}x${size}.png`))
+      } else {
+        let iconPath = '/png/32x32.png'
+        if (process.platform === 'darwin' || process.platform === 'win32') {
+          iconPath = platformIcons[process.platform]
+        }
+        this._tray = new Tray(path.join(__dirname, 'assets/icons', iconPath))
+      }
+
+      const contextMenu = Menu.buildFromTemplate([
+        {
+          label: 'Show Zettlr',
+          click: show,
+          type: 'normal'
+        },
+        { label: '', type: 'separator' },
+        {
+          label: 'Quit',
+          click: quit,
+          type: 'normal'
+        }
+      ])
+      this._tray.setToolTip('This is the Zettlr tray. \n Select Show Zettlr to show the Zettlr app. \n Select Quit to quit the Zettlr app.')
+      this._tray.setContextMenu(contextMenu)
+    }
+  }
+
+  /**
+   * Removes the Zettlr tray from the system notification area.
+   * @private
+   * @memberof TrayProvider
+   */
+  private _removeTray (): void {
+    if (this._tray != null) {
+      this._tray.destroy()
+    }
+    this._tray = null
+  }
+}

--- a/source/global.d.ts
+++ b/source/global.d.ts
@@ -64,5 +64,6 @@ declare module NodeJS {
     stats: StatsProvider
     i18n: any
     i18nFallback: any
+    tray: TrayProvider
   }
 }


### PR DESCRIPTION
Refactor tray code into a tray service provider.

As nathanlesage's [comment](https://github.com/Zettlr/Zettlr/pull/1959#issuecomment-839944595):

> Indeed, I think the tray is something that should reside within its own service provider (since the Tray will be there for as long as the app runs if the user has selected the appropriate option). Furthermore, having the Tray logic in its own dedicated provider we can add more functionality to it more easily.

> With regard to how the question of how to access the showAnyWindow-function from within a service provider, I recommend you have a look at the MenuProvider. I faced the same problem and I think I solved it quite elegantly by running an App-command (since the app object itself has access to everything).

I didn't exactly implement like [MenuProvider](https://github.com/UofA-SPI21-team7/Zettlr/blob/9a5b0170e8ef95b217fa302977785ac87bd839f6/source/app/service-providers/menu-provider.ts#L86) because [MenuProvider](https://github.com/UofA-SPI21-team7/Zettlr/blob/9a5b0170e8ef95b217fa302977785ac87bd839f6/source/app/service-providers/menu-provider.ts#L86) runs on the `main` process and provides services to the `renderer` process. IPC is needed.

I implemented like [RecentDocsProvider](https://github.com/UofA-SPI21-team7/Zettlr/blob/9a5b0170e8ef95b217fa302977785ac87bd839f6/source/app/service-providers/recent-docs-provider.ts#L23). Because [WindowManager](https://github.com/UofA-SPI21-team7/Zettlr/blob/9a5b0170e8ef95b217fa302977785ac87bd839f6/source/main/modules/window-manager/index.ts#L59) and [TrayProvider](https://github.com/UofA-SPI21-team7/Zettlr/blob/9a5b0170e8ef95b217fa302977785ac87bd839f6/source/app/service-providers/tray-provider.ts#L26) both run on the `main` process and IPC is not needed.

Closes #60