### PR TITLE
Don't show save changes dialog when hiding window

### DIFF
--- a/source/global.d.ts
+++ b/source/global.d.ts
@@ -16,6 +16,7 @@ declare module '*.png'
 interface Application {
   runCommand: (command: string, payload?: any) => Promise<any>
   isBooting: () => boolean
+  isQuiting: () => boolean
   showLogViewer: () => void
   showPreferences: () => void
   showCustomCSS: () => void

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -353,14 +353,10 @@ export default class WindowManager {
           win.close()
         }
       }
-      if (process.platform === 'win32' || process.platform === 'linux') {
-        const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
-        if (leaveAppRunning) {
-          this._mainWindow?.hide()
-        }
-      }
-
-      if (this._beforeMainWindowCloseCallback !== null) {
+      if (process.platform !== 'darwin' && Boolean(global.config.get('system.leaveAppRunning')) && !global.application.isQuiting()) {
+        this._mainWindow?.hide()
+        event.preventDefault()
+      } else if (this._beforeMainWindowCloseCallback !== null) {
         const shouldClose: boolean = this._beforeMainWindowCloseCallback()
         if (!shouldClose) {
           event.preventDefault()

--- a/source/main/zettlr.ts
+++ b/source/main/zettlr.ts
@@ -34,6 +34,7 @@ import broadcastIpcMessage from '../common/util/broadcast-ipc-message'
 
 export default class Zettlr {
   isBooting: boolean
+  isQuiting: boolean
   editFlag: boolean
   _openPaths: any
   _fsal: FSAL
@@ -47,6 +48,7 @@ export default class Zettlr {
     */
   constructor () {
     this.isBooting = true // Only is true until the main process has fully loaded
+    this.isQuiting = false // Is the app quiting?
     this.editFlag = false // Is the current opened file edited?
     this._openPaths = [] // Holds all currently opened paths.
     this.isShownFor = [] // Contains all files for which remote notifications are currently shown
@@ -64,6 +66,9 @@ export default class Zettlr {
       // Flag indicating whether or not the application is booting
       isBooting: () => {
         return this.isBooting
+      },
+      isQuiting: () => {
+        return this.isQuiting
       },
       showLogViewer: () => {
         this._windowManager.showLogWindow()
@@ -142,9 +147,11 @@ export default class Zettlr {
     // listen to close-events on the main window, we should be able to handle
     // this, if we ever switched to the auto updater.
     app.on('before-quit', (event) => {
+      this.isQuiting = true
       if (!this._fsal.isClean()) {
         // Immediately prevent quitting ...
         event.preventDefault()
+        this.isQuiting = false
         // ... and ask the user if we should *really* quit.
         this._windowManager.askSaveChanges()
           .then(result => {


### PR DESCRIPTION
When `Leave app running in the notification area` is true, and the user closes the window, don't show the save the save changes dialog. The app hasn't quit and is still active in the tray. The user will have a chance to save changes when the app really quits.

Closes #61