### PR TITLE
Localise the tray

### DIFF
--- a/source/app/service-providers/tray-provider.ts
+++ b/source/app/service-providers/tray-provider.ts
@@ -19,6 +19,7 @@ import {
 } from 'electron'
 import path from 'path'
 import EventEmitter from 'events'
+import { trans } from '../../common/i18n'
 
 /**
  * This class generates the Tray in the system notification area
@@ -113,18 +114,18 @@ export default class TrayProvider extends EventEmitter {
 
       const contextMenu = Menu.buildFromTemplate([
         {
-          label: 'Show Zettlr',
+          label: trans('tray.show_zettlr'),
           click: show,
           type: 'normal'
         },
         { label: '', type: 'separator' },
         {
-          label: 'Quit',
+          label: trans('menu.quit'),
           click: quit,
           type: 'normal'
         }
       ])
-      this._tray.setToolTip('This is the Zettlr tray.\nSelect Show Zettlr to show the Zettlr app.\nSelect Quit to quit the Zettlr app.')
+      this._tray.setToolTip(trans('tray.tooltip'))
       this._tray.setContextMenu(contextMenu)
     }
   }

--- a/source/app/util/environment-check.ts
+++ b/source/app/util/environment-check.ts
@@ -17,6 +17,7 @@ import { app } from 'electron'
 import { promises as fs } from 'fs'
 import { spawn } from 'child_process'
 import isFile from '../../common/util/is-file'
+import { trans } from '../../common/i18n'
 
 /**
  * Contains custom paths that should be present on the process.env.PATH property
@@ -170,17 +171,11 @@ export async function isTraySupported (): Promise<boolean> {
 
       shellProcess.on('close', (code, signal) => {
         if (code !== 0) {
-          reject(new Error('Tray is not supported. Gnome ' +
-            'Extension "KStatusNotifierItem/AppIndicator Support" is ' +
-            'required for Tray support on the Gnome Desktop.'
-          )) // trans('system.error.tray_not_supported')
+          reject(new Error(trans('system.error.tray_not_supported')))
         } else if (out.includes("'appindicatorsupport@rgcjonas.gmail.com'")) {
           resolve(true)
         } else {
-          reject(new Error('Tray is not supported. Gnome ' +
-            'Extension "KStatusNotifierItem/AppIndicator Support" is ' +
-            'required for Tray support on the Gnome Desktop.'
-          )) // trans('system.error.tray_not_supported')
+          reject(new Error(trans('system.error.tray_not_supported')))
         }
       })
 

--- a/source/win-preferences/schema/advanced.js
+++ b/source/win-preferences/schema/advanced.js
@@ -38,7 +38,9 @@ export default {
       },
       {
         type: 'checkbox',
-        label: process.platform === 'darwin' ? 'Show app in the notification area' : 'Leave app running in the notification area',
+        label: process.platform === 'darwin'
+          ? trans('dialog.preferences.show_app_in_the_notification_area')
+          : trans('dialog.preferences.leave_app_running_in_the_notification_area'),
         model: 'system.leaveAppRunning'
       }
     ],


### PR DESCRIPTION
Localise the tray strings - user facing (not the logs). Requires the translation strings to be added to Zettlr Translate. The translation strings will be added by nathanlesage_.
Addresses comment https://github.com/Zettlr/Zettlr/pull/1959#pullrequestreview-666249085

Below are the strings I will ask nathanlesage_ to add when our team raises a Zettlr pull request.

```json
{
    "dialog": {
        "preferences": {
            "leave_app_running_in_the_notification_area": "Leave app running in the notification area",
            "show_app_in_the_notification_area": "Show app in the notification area"
        }
    },
    "system": {
        "error": {
            "tray_not_supported": "Tray is not supported. Gnome Extension &quot;KStatusNotifierItem/AppIndicator Support&quot; is required for Tray support on the Gnome Desktop."
        }
    },
    "tray": {
        "show_zettlr": "Show Zettlr",
        "tooltip": "This is the Zettlr tray.\nSelect Show Zettlr to show the Zettlr app.\nSelect Quit to quit the Zettlr app."
    }
}
```

**NOTE**: With this code change, Zettlr will error when showing the Preferences:
```
[08:00:25] [R] [Preferences] Uncaught TypeError: Cannot read property 'get' of undefined (index.js:36694)
{}
```
This above error will go away when nathanlesage_ adds the above strings to Zettlr Translate website.

Closes #68