### PR TITLE
Correct compile error on `platformIcons` keys

### DIFF
--- a/source/app/service-providers/tray-provider.ts
+++ b/source/app/service-providers/tray-provider.ts
@@ -97,7 +97,7 @@ export default class TrayProvider extends EventEmitter {
    */
   private _addTray (show: () => void, quit: () => void): void {
     if (this._tray == null) {
-      const platformIcons: { [key in 'darwin' | 'win32']: string } = {
+      const platformIcons: { [key: string]: string } = {
         'darwin': '/png/22x22_white.png',
         'win32': '/icon.ico'
       }


### PR DESCRIPTION
The compile error was:
TS7053: Element implicitly has an 'any' type because expression of type
'"aix" | "android" | "darwin" | "freebsd" | "openbsd" | "sunos"
| "win32" | "cygwin" | "netbsd"' can't be used to index type
'{ darwin: string; win32: string; }'. Property 'aix' does not exist on
type '{ darwin: string; win32: string; }'.

Closes #76 