### PR TITLE
Info text smaller and grey

### DIFF
--- a/source/common/vue/form/elements/Checkbox.vue
+++ b/source/common/vue/form/elements/Checkbox.vue
@@ -6,7 +6,9 @@
       >
         <input
           v-bind:id="fieldID"
-          type="checkbox" v-bind:name="name" value="yes"
+          type="checkbox"
+          v-bind:name="name"
+          value="yes"
           v-bind:checked="value"
           v-bind:disabled="disabled"
           v-on:input="$emit('input', $event.target.checked)"
@@ -18,7 +20,7 @@
       >
       </label>
     </div>
-    <div v-if="info" class="form-control">
+    <div v-if="info" class="form-control info">
       {{ info }}
     </div>
   </div>
@@ -135,10 +137,15 @@ body {
     }
   }
 
-  label{
+  label {
     &[disabled] {
       color: grey;
     }
+  }
+
+  div.info {
+    color: grey;
+    font-size: 80%;
   }
 }
 


### PR DESCRIPTION
If the tray is not supported (Linux Gnome only with missing Gnome
Extension), set the info text in the preference dialog to be smaller
and grey.

Addresses comment https://github.com/Zettlr/Zettlr/pull/2026#discussion_r645963610

Format Checkbox html

Addresses comment https://github.com/Zettlr/Zettlr/pull/2026#discussion_r645695568

Closes #80 