### PR TITLE
Move tray config change listener to tray-provider

### DIFF
--- a/source/app/service-providers/assets/types.tray-provider.d.ts
+++ b/source/app/service-providers/assets/types.tray-provider.d.ts
@@ -1,4 +1,3 @@
 interface TrayProvider {
-  add: (show: () => void, quit: () => void) => void
-  remove: () => void
+  add: () => void
 }

--- a/source/app/service-providers/tray-provider.ts
+++ b/source/app/service-providers/tray-provider.ts
@@ -15,7 +15,9 @@
 import {
   Tray,
   Menu,
-  screen
+  MenuItemConstructorOptions,
+  screen,
+  app
 } from 'electron'
 import path from 'path'
 import EventEmitter from 'events'
@@ -29,6 +31,7 @@ export default class TrayProvider extends EventEmitter {
    * The tray
    */
   private _tray: Tray | null
+  private readonly _menu: MenuItemConstructorOptions[]
 
   /**
    * Create the instance on program start and setup services.
@@ -37,20 +40,42 @@ export default class TrayProvider extends EventEmitter {
     super()
     global.log.verbose('Tray provider booting up ...')
     this._tray = null
+    this._menu = [
+      {
+        label: trans('tray.show_zettlr'),
+        click: () => global.application.showAnyWindow(),
+        type: 'normal'
+      },
+      { label: '', type: 'separator' },
+      {
+        label: trans('menu.quit'),
+        click: () => app.quit(),
+        type: 'normal'
+      }
+    ]
 
     global.tray = {
       /**
-       * Add a document to the list of recently opened documents
-       * @param {Object} doc A document exposing at least the metadata of the file
+       * Adds the Zettlr tray to the system notification area.
        */
-      add: (show: () => void, quit: () => void) => {
-        this._addTray(show, quit)
-      },
-
-      remove: () => {
-        this._removeTray()
+      add: () => {
+        this._addTray()
       }
     }
+
+    if (process.env.ZETTLR_IS_TRAY_SUPPORTED === '0') {
+      global.config.set('system.leaveAppRunning', false)
+    }
+
+    global.config.on('update', (option: string) => {
+      if (option === 'system.leaveAppRunning') {
+        if (global.config.get('system.leaveAppRunning') === true) {
+          this._addTray()
+        } else {
+          this._removeTray()
+        }
+      }
+    })
   }
 
   /**
@@ -95,8 +120,9 @@ export default class TrayProvider extends EventEmitter {
    * @private
    * @memberof TrayProvider
    */
-  private _addTray (show: () => void, quit: () => void): void {
-    if (this._tray == null) {
+  private _addTray (): void {
+    const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
+    if (this._tray == null && leaveAppRunning) {
       const platformIcons: { [key: string]: string } = {
         'darwin': '/png/22x22_white.png',
         'win32': '/icon.ico'
@@ -112,19 +138,7 @@ export default class TrayProvider extends EventEmitter {
         this._tray = new Tray(path.join(__dirname, 'assets/icons', iconPath))
       }
 
-      const contextMenu = Menu.buildFromTemplate([
-        {
-          label: trans('tray.show_zettlr'),
-          click: show,
-          type: 'normal'
-        },
-        { label: '', type: 'separator' },
-        {
-          label: trans('menu.quit'),
-          click: quit,
-          type: 'normal'
-        }
-      ])
+      const contextMenu = Menu.buildFromTemplate(this._menu)
       this._tray.setToolTip(trans('tray.tooltip'))
       this._tray.setContextMenu(contextMenu)
     }

--- a/source/global.d.ts
+++ b/source/global.d.ts
@@ -36,6 +36,7 @@ interface Application {
   showAboutWindow: () => void
   showDefaultsPreferences: () => void
   showTagManager: () => void
+  showAnyWindow: () => void
   notifyChange: (msg: string) => void
   findFile: (prop: any) => MDFileDescriptor | CodeFileDescriptor | null
   findDir: (prop: any) => DirDescriptor | null

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -183,16 +183,6 @@ export default class WindowManager {
       let dir = await this.askDir(focusedWindow)
       return dir
     })
-
-    global.config.on('update', (option: string) => {
-      if (option === 'system.leaveAppRunning') {
-        if (global.config.get('system.leaveAppRunning') === true) {
-          global.tray.add(() => this.showAnyWindow(), () => app.quit())
-        } else {
-          global.tray.remove()
-        }
-      }
-    })
   }
 
   /**
@@ -242,10 +232,7 @@ export default class WindowManager {
     }
 
     this._mainWindow.on('show', () => {
-      const leaveAppRunning = Boolean(global.config.get('system.leaveAppRunning'))
-      if (leaveAppRunning) {
-        global.tray.add(() => this.showAnyWindow(), () => app.quit())
-      }
+      global.tray.add()
     })
 
     // Listens to events from the window

--- a/source/main/zettlr.ts
+++ b/source/main/zettlr.ts
@@ -86,6 +86,9 @@ export default class Zettlr {
       showTagManager: () => {
         this._windowManager.showTagManager()
       },
+      showAnyWindow: () => {
+        this._windowManager.showAnyWindow()
+      },
       notifyChange: (msg: string) => {
         global.notify.normal(msg)
       },

--- a/source/win-preferences/preferences.vue
+++ b/source/win-preferences/preferences.vue
@@ -271,7 +271,6 @@ export default {
     if (process.env.ZETTLR_IS_TRAY_SUPPORTED === '0') {
       const leaveAppRunningField = modelToField('system.leaveAppRunning', SCHEMA['tab-advanced'])
       if (leaveAppRunningField !== undefined) {
-        global.config.set('system.leaveAppRunning', false)
         leaveAppRunningField.disabled = true
         if (process.env.ZETTLR_TRAY_ERROR !== undefined) {
           leaveAppRunningField.info = '⚠️ ' + process.env.ZETTLR_TRAY_ERROR


### PR DESCRIPTION
Move config change listener 'system.leaveAppRunning' to tray-provider.
Provide access to global.application.showAnyWindow() in tray-provider.

Addresses comments https://github.com/Zettlr/Zettlr/pull/2026#discussion_r645698785 and https://github.com/Zettlr/Zettlr/pull/2026#discussion_r645963731

Closes #81 