### PR TITLE
Correct spelling isQuiting -> isQuitting

### DIFF
--- a/source/global.d.ts
+++ b/source/global.d.ts
@@ -29,7 +29,7 @@ declare module '*.png'
  */
 interface Application {
   runCommand: (command: string, payload?: any) => Promise<any>
-  isQuiting: () => boolean
+  isQuitting: () => boolean
   showLogViewer: () => void
   showPreferences: () => void
   displayErrorMessage: (title: string, message: string, contents?: string) => void

--- a/source/main/modules/window-manager/index.ts
+++ b/source/main/modules/window-manager/index.ts
@@ -280,7 +280,7 @@ export default class WindowManager {
           win.close()
         }
       }
-      if (process.platform !== 'darwin' && Boolean(global.config.get('system.leaveAppRunning')) && !global.application.isQuiting()) {
+      if (process.platform !== 'darwin' && Boolean(global.config.get('system.leaveAppRunning')) && !global.application.isQuitting()) {
         this._mainWindow?.hide()
         event.preventDefault()
       } else if (this._beforeMainWindowCloseCallback !== null) {

--- a/source/main/zettlr.ts
+++ b/source/main/zettlr.ts
@@ -36,7 +36,7 @@ import { CodeFileDescriptor, CodeFileMeta, DirDescriptor, MDFileDescriptor, MDFi
 import broadcastIpcMessage from '../common/util/broadcast-ipc-message'
 
 export default class Zettlr {
-  isQuiting: boolean
+  isQuitting: boolean
   editFlag: boolean
   _openPaths: any
   _fsal: FSAL
@@ -50,7 +50,9 @@ export default class Zettlr {
     * @param {electron.app} parentApp The app object.
     */
   constructor () {
-    this.isQuiting = false // Is the app quiting?
+    // Is the app quitting? True if quitting via menu, tray or keyboard shortcut.
+    // False if titlebar `x` close, and all other times.
+    this.isQuitting = false
     this.editFlag = false // Is the current opened file edited?
     this._openPaths = [] // Holds all currently opened paths.
     this.isShownFor = [] // Contains all files for which remote notifications are currently shown
@@ -65,8 +67,8 @@ export default class Zettlr {
       runCommand: async (command: string, payload?: any) => {
         return await this.runCommand(command, payload)
       },
-      isQuiting: () => {
-        return this.isQuiting
+      isQuitting: () => {
+        return this.isQuitting
       },
       showLogViewer: () => {
         this._windowManager.showLogWindow()
@@ -134,11 +136,11 @@ export default class Zettlr {
     // listen to close-events on the main window, we should be able to handle
     // this, if we ever switched to the auto updater.
     app.on('before-quit', (event) => {
-      this.isQuiting = true
+      this.isQuitting = true
       if (!this._documentManager.isClean()) {
         // Immediately prevent quitting ...
         event.preventDefault()
-        this.isQuiting = false
+        this.isQuitting = false
         // ... and ask the user if we should *really* quit.
         this._windowManager.askSaveChanges()
           .then(result => {


### PR DESCRIPTION
Correct spelling isQuiting -> isQuitting. Add a comment to explain the
purpose of isQuitting.
Addresses comments https://github.com/Zettlr/Zettlr/pull/2026#discussion_r645699497 and https://github.com/Zettlr/Zettlr/pull/2026#discussion_r645696294

Closes #82 